### PR TITLE
[wip] React Komposer instead of mixins

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "utilities:react-list-container",
   summary: "List container for React",
-  version: "0.1.12",
+  version: "0.1.13",
   git: "https://github.com/meteor-utilities/react-list-container.git"
 });
 


### PR DESCRIPTION
I found a way to use react-komposer dynamically with DocumentContainer & ListContainer, tested it in practice on Nova.

After reading different issues & discussions, in order to fit more with the react way,I defined `component` as a required props, so there is now only one-way to "contain": `<Container component={MyDumbComp} />`. 

I'm having some issues with the infinite scrolling, the whole list re-renders. I guess it's related to https://github.com/kadirahq/react-komposer/issues/2 & https://github.com/kadirahq/react-komposer/issues/4, maybe it'll be fixed with https://github.com/kadirahq/react-komposer/pull/99.

Any feedback welcomed 👍 
